### PR TITLE
Page Links Update

### DIFF
--- a/_pages.json
+++ b/_pages.json
@@ -1,7 +1,7 @@
 [{
     "name": "Meetup Locations",
     "desc": "Using LeafletJS to visualize the locations of meetup events.",
-    "link": "meetup-locations/index.html",
+    "link": "pages/meetup-locations/index.html",
     "auth": "Sean O'Mahoney",
     "aURL": "https://twitter.com/Sean12697"
 }]

--- a/script.js
+++ b/script.js
@@ -44,7 +44,7 @@ module.exports = (groups, events, attendees) => {
 
     let pages = require("./_pages.json").map(page => {
         return {
-            name: `<a href="pages/${page.link}" target="_blank">${page.name}</a>`,
+            name: `<a href="${page.link}" target="_blank">${page.name}</a>`,
             desc: `${page.desc}<br/><br/>Author: <a href="${page.aURL}" target="_blank">${page.auth}</a>`,
             slug: ``
         }


### PR DESCRIPTION
Moving the enforced href location (that being "pages/") of linked experiments will allow any website that has used the data to be linked within the configuration of the site.